### PR TITLE
Update README to improve deps config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can read more about this in [my blog post about the project](http://www.greg
   1. Add it to your list of dependencies in `mix.exs`:
 
         def deps do
-          [{:nerves_neopixel, "~> 0.1.0"}]
+          [{:nerves_neopixel, "~> 0.3.0", github: "GregMefford/nerves_neopixel", submodules: true}]
         end
 
   2. Ensure it is started before your application:


### PR DESCRIPTION
- Pointing to the Hex package in deps and compiling results in this error: 

```
$ mix deps.compile nerves_neopixel
==> nerves_neopixel
Unchecked dependencies for environment prod:
* elixir_make (Hex package)
  the dependency is not locked (run "mix deps.get" to generate "mix.lock" file)
could not compile dependency :nerves_neopixel, "mix compile" failed. You can recompile this dependency with "mix deps.compile nerves_neopixel", update it with "mix deps.update nerves_neopixel" or clean it with "mix deps.clean nerves_neopixel"
```
- The `GregMefford/nerves_neopixel` repository is configured with a submodule for `jgarff/rpi_ws281x`. This makes compilation of `nerves_neopixel` from github fail without the `submodules` flag in `deps/0`. 

This PR updates the README to recommend a happy path to resolution.
