### PR TITLE
Update dep version to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can read more about this in [my blog post about the project](http://www.greg
   1. Add it to your list of dependencies in `mix.exs`:
 
         def deps do
-          [{:nerves_neopixel, "~> 0.1.0"}]
+          [{:nerves_neopixel, "~> 0.3.0"}]
         end
 
   2. Ensure it is started before your application:


### PR DESCRIPTION
Hex lists nerves_neopixel as version 0.3.0 but the README shows configuration with version 0.1.0. 0.3.0 is also not listed under "Releases" for the GitHub repository

It looks like #2 already tries to fix this but specifically points to GitHub which may not be ideal.

Connects to #3 but I haven't figured out how to update the example yet