### PR TITLE
Upgrade rpi_ws281x in order to support rpi0w

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ CC ?= $(CROSSCOMPILER)gcc
 
 SRC = $(wildcard src/*.c) src/rpi_ws281x/dma.c src/rpi_ws281x/mailbox.c \
   src/rpi_ws281x/mailbox.c src/rpi_ws281x/pwm.c src/rpi_ws281x/rpihw.c \
-	src/rpi_ws281x/ws2811.c
+	src/rpi_ws281x/pcm.c src/rpi_ws281x/ws2811.c
 
 OBJ = $(SRC:.c=.o)
 


### PR DESCRIPTION
I upgraded the rpi_ws281x library in order to support the rpi0w. It probably was only necessary to pull in https://github.com/jgarff/rpi_ws281x/commit/4d1c36383dfded2df9d465bacefff24fc93ff68f but I went ahead and updated to the current master branch.

I tested the changes on a Unicorn HAT.