### PR TITLE
Make DMA channel configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,19 @@ Blinkchain.render()
 
 To see more about how this code works or try it out for yourself, check out
 [the included `rainbow` example](https://github.com/GregMefford/blinkchain/tree/master/examples/rainbow).
+
+## DMA Channel Selection
+
+We have occasionally seen issues on particular combinations of hardware and
+Raspberry Pi-provided firmware versions where there is a conflict between the
+DMA channels used by Blinkchain and the ones used internally by the Raspberry
+Pi firmware. You will probably never need to change this, but in case you
+experience stability issues where the OS process is crashing, you might want to
+try changing the DMA channel to see if that helps.
+
+```elixir
+# config/config.exs
+use Mix.Config
+
+config :blinkchain, dma_channel: 5 # <= The default is 5
+```

--- a/lib/blinkchain/config.ex
+++ b/lib/blinkchain/config.ex
@@ -14,13 +14,15 @@ defmodule Blinkchain.Config do
   @type t :: %__MODULE__{
           canvas: Canvas.t(),
           channel0: Channel.t(),
-          channel1: Channel.t()
+          channel1: Channel.t(),
+          dma_channel: non_neg_integer()
         }
 
   defstruct [
     :canvas,
     :channel0,
-    :channel1
+    :channel1,
+    :dma_channel
   ]
 
   @doc """
@@ -52,7 +54,8 @@ defmodule Blinkchain.Config do
     %Config{
       canvas: canvas,
       channel0: channel0,
-      channel1: channel1
+      channel1: channel1,
+      dma_channel: Application.get_env(:blinkchain, :dma_channel, 5)
     }
   end
 

--- a/lib/blinkchain/hal.ex
+++ b/lib/blinkchain/hal.ex
@@ -37,11 +37,15 @@ defmodule Blinkchain.HAL do
       |> Path.join("rpi_ws281x")
       |> String.to_charlist()
 
-    args =
-      Enum.flat_map(
-        [config.channel0, config.channel1],
-        fn ch -> ["#{ch.pin}", "#{Channel.total_count(ch)}", "#{ch.type}"] end
-      )
+    args = [
+      "#{config.dma_channel}",
+      "#{config.channel0.pin}",
+      "#{Channel.total_count(config.channel0)}",
+      "#{config.channel0.type}",
+      "#{config.channel1.pin}",
+      "#{Channel.total_count(config.channel1)}",
+      "#{config.channel1.type}"
+    ]
 
     port =
       Port.open({:spawn_executable, filename}, [

--- a/src/rpi_ws281x.c
+++ b/src/rpi_ws281x.c
@@ -10,8 +10,6 @@
 #include "base64.h"
 #include "port_interface.h"
 
-#define DMA_CHANNEL 10
-
 typedef struct {
   uint16_t width;
   uint16_t height;
@@ -336,20 +334,21 @@ void blit(ws2811_channel_t *channels, const canvas_t *canvas) {
 }
 
 int main(int argc, char *argv[]) {
-  if (argc != 7 && argc != 4)
-    errx(EXIT_FAILURE, "Usage: %s <Channel 1 Pin> <Channel 1 Count> <Channel 1 Type> [<Channel 2 Pin> <Channel 2 Count> <Channel 2 Type>]", argv[0]);
+  if (argc != 8 && argc != 5)
+    errx(EXIT_FAILURE, "Usage: %s <DMA Channel> <Channel 1 Pin> <Channel 1 Count> <Channel 1 Type> [<Channel 2 Pin> <Channel 2 Count> <Channel 2 Type>]", argv[0]);
 
-  uint8_t gpio_pin1 = atoi(argv[1]);
-  uint32_t led_count1 = strtol(argv[2], NULL, 10);
-  int strip_type1 = parse_strip_type(argv[3]);
+  uint8_t dma_channel = atoi(argv[1]);
+  uint8_t gpio_pin1 = atoi(argv[2]);
+  uint32_t led_count1 = strtol(argv[3], NULL, 10);
+  int strip_type1 = parse_strip_type(argv[4]);
 
   uint8_t gpio_pin2 = 0;
   uint32_t led_count2 = 0;
   int strip_type2 = WS2811_STRIP_GBR;
-  if (argc == 7) {
-    gpio_pin2 = atoi(argv[4]);
-    led_count2 = strtol(argv[5], NULL, 10);
-    strip_type2 = parse_strip_type(argv[6]);
+  if (argc == 8) {
+    gpio_pin2 = atoi(argv[5]);
+    led_count2 = strtol(argv[6], NULL, 10);
+    strip_type2 = parse_strip_type(argv[7]);
   }
 
   /*
@@ -357,7 +356,7 @@ int main(int argc, char *argv[]) {
   */
   ws2811_t ledstring = {
     .freq = WS2811_TARGET_FREQ,
-    .dmanum = DMA_CHANNEL,
+    .dmanum = dma_channel,
     .channel = {
       [0] = {
         .gpionum = gpio_pin1,


### PR DESCRIPTION
Changes the default DMA channel from 10 to 5 [like it used to be forever ago](https://github.com/GregMefford/blinkchain/blob/63395d56fffdc9d8e85b676663c6388c5f339cdc/src/rpi_ws281x.c#L16) and makes it configurable in case there's another regression in the future.

I suspect that this is related to the version of the RPi Firmware that's being used, so it's possible that `10` is still the right number to use if you're on an old version of a Nerves system that has an old rpi-firmware.

Resolves #20