### PR TITLE
Always build embedded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ $(BUILD)/%.o: src/%.c $(BUILD) $(BUILD)/rpi_ws281x
 
 $(PREFIX)/blinkchain: $(OBJ)
 	$(CC) $^ $(LDFLAGS) -o $@
+ifeq ($(CROSSCOMPILE),)
+	$(warning No cross-compiler detected. Building Blinkchain native code in test mode.)
+	$(warning If you were intending to build in normal mode e.g. directly on a Raspberry Pi,)
+	$(warning you can force it by running `CROSS_COMPILE=true mix compile`)
+endif
 
 clean:
 	rm -rf $(PREFIX)/* $(BUILD)/*

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,58 @@
 # Variables to override
 #
 # CC            C compiler
-# CROSSCOMPILE	crosscompiler prefix, if any
-# CFLAGS	compiler flags for compiling all C files
-# LDFLAGS	linker flags for linking all binaries
+# CROSSCOMPILE  crosscompiler prefix, if any
+# CFLAGS        compiler flags for compiling all C files
+# LDFLAGS       linker flags for linking all binaries
 
-LDFLAGS +=
+# Initialize some variables if not set
+LDFLAGS ?=
+CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter
+CC ?= $(CROSSCOMPILE)-gcc
 
 CFLAGS += -std=gnu99
+
+ifeq ($(MIX_COMPILE_PATH),)
+  $(error MIX_COMPILE_PATH should be set by elixir_make!)
+endif
+
+PREFIX = $(MIX_COMPILE_PATH)/../priv
+BUILD  = $(MIX_COMPILE_PATH)/../obj
 
 ifeq ($(CROSSCOMPILE),)
 # Host testing build
 CFLAGS += -DDEBUG
 SRC = src/rpi_ws281x.c src/fake_ws2811.c
-endif
-ifneq ($(CROSSCOMPILE),)
+else
 # Normal build
 SRC = src/rpi_ws281x.c src/rpi_ws281x/dma.c src/rpi_ws281x/mailbox.c \
-	src/rpi_ws281x/mailbox.c src/rpi_ws281x/pwm.c src/rpi_ws281x/rpihw.c \
-	src/rpi_ws281x/pcm.c src/rpi_ws281x/ws2811.c
+  src/rpi_ws281x/mailbox.c src/rpi_ws281x/pwm.c src/rpi_ws281x/rpihw.c \
+  src/rpi_ws281x/pcm.c src/rpi_ws281x/ws2811.c
 endif
 
-OBJ = $(SRC:.c=.o)
+OBJ = $(patsubst src/%,$(BUILD)/%,$(SRC:.c=.o))
 
-.PHONY: all clean
+calling_from_make:
+	mix compile
 
-all: priv/rpi_ws281x
+all: $(PREFIX) $(PREFIX)/blinkchain
 
-%.o: %.c
-	$(CC) -c $(CFLAGS) -o $@ $<
+$(PREFIX):
+	mkdir -p $@
 
-priv/rpi_ws281x: $(OBJ)
-	@mkdir -p priv
+$(BUILD):
+	mkdir -p $@
+
+$(BUILD)/rpi_ws281x:
+	mkdir -p $@
+
+$(BUILD)/%.o: src/%.c $(BUILD) $(BUILD)/rpi_ws281x
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(PREFIX)/blinkchain: $(OBJ)
 	$(CC) $^ $(LDFLAGS) -o $@
 
 clean:
-	rm -f priv/rpi_ws281x src/*.o src/rpi_ws281x/*.o
+	rm -rf $(PREFIX)/* $(BUILD)/*
+
+.PHONY: all clean calling_from_make

--- a/lib/blinkchain/hal.ex
+++ b/lib/blinkchain/hal.ex
@@ -34,7 +34,7 @@ defmodule Blinkchain.HAL do
     filename =
       :blinkchain
       |> :code.priv_dir()
-      |> Path.join("rpi_ws281x")
+      |> Path.join("blinkchain")
       |> String.to_charlist()
 
     args = [

--- a/mix.exs
+++ b/mix.exs
@@ -10,8 +10,9 @@ defmodule Blinkchain.Mixfile do
       description: "Drive WS2812B \"NeoPixel\" RGB LED strips from a Raspberry Pi using Elixir.",
       elixir: "~> 1.6",
       make_clean: ["clean"],
+      make_targets: ["all"],
       compilers: [:elixir_make | Mix.compilers()],
-      build_embedded: Mix.env() == :prod,
+      build_embedded: true,
       start_permanent: Mix.env() == :prod,
       package: package(),
       aliases: [
@@ -40,7 +41,7 @@ defmodule Blinkchain.Mixfile do
     [
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
-      {:elixir_make, "~> 0.4", runtime: false},
+      {:elixir_make, "~> 0.6", runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev], runtime: false},
       {:excoveralls, "~> 0.10", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
   "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
   "elixir_ale": {:hex, :elixir_ale, "0.3.0"},
-  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], []},
+  "elixir_make": {:hex, :elixir_make, "0.6.0", "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.10.3", "b090a3fbcb3cfa136f0427d038c92a9051f840953ec11b40ee74d9d4eac04d1e", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "exrm": {:hex, :exrm, "0.15.3"},


### PR DESCRIPTION
Solves issues with switching between different targets without having to manually clean and recompile.

Resolves #17 